### PR TITLE
Remove depth pre-pass and make water opaque

### DIFF
--- a/src/riverborn/mgl_terrain.py
+++ b/src/riverborn/mgl_terrain.py
@@ -545,22 +545,22 @@ class WaterApp(mglw.WindowConfig):
             self.scene.draw(self.camera, self.light)
 
         self.water_prog["env_cube"].value = 1
-        self.water_prog["near"].value = 0.1
-        self.water_prog["far"].value = 1000.0
-        self.water_prog["resolution"].value = self.wnd.size
+        # self.water_prog["near"].value = 0.1
+        # self.water_prog["far"].value = 1000.0
+        # self.water_prog["resolution"].value = self.wnd.size
         self.water_prog["m_model"].write(self.water_model)
         self.env_cube.use(location=1)
         self.water_prog["env_cube"].value = 1
 
         self.water_sim.texture.use(location=0)
         self.water_prog["height_map"].value = 0
-        self.water_prog['base_water'] = (0.2, 0.15, 0.1)
-        self.water_prog['water_opaque_depth'] = 3
+        self.water_prog['base_water'] = (0.1, 0.05, 0.00)
+        #self.water_prog['water_opaque_depth'] = 3
 
         self.camera.bind(self.water_prog, pos_uniform="camera_pos")
-        x, y, w, h = self.wnd.viewport
-        self.water_prog["resolution"].value = self.wnd.size
-        with self.ctx.scope(enable_only=moderngl.BLEND):
+        #x, y, w, h = self.wnd.viewport
+        #self.water_prog["resolution"].value = self.wnd.size
+        with self.ctx.scope(enable_only=moderngl.BLEND | moderngl.DEPTH_TEST):
             self.water_vao.render()
 
         if self.recorder is not None:
@@ -579,7 +579,7 @@ class WaterApp(mglw.WindowConfig):
         #     )
 
     def on_resize(self, width: int, height: int):
-        self.water_prog["resolution"].value = (width, height)
+        #self.water_prog["resolution"].value = (width, height)
         # Create the camera.
         self.camera.set_aspect(width / height)
         self.ctx.gc()

--- a/src/riverborn/mgl_terrain.py
+++ b/src/riverborn/mgl_terrain.py
@@ -540,35 +540,22 @@ class WaterApp(mglw.WindowConfig):
         # ------------------------------
         # First pass: Render scene into offscreen framebuffer.
         # ------------------------------
-        with self.ctx.scope(framebuffer=self.offscreen_fbo, enable=moderngl.DEPTH_TEST):
+        with self.ctx.scope(enable=moderngl.DEPTH_TEST):
             self.ctx.clear(0.6, 0.7, 1.0, 1.0)
             self.scene.draw(self.camera, self.light)
 
-        copy_shader = load_shader("copy")
-        copy_shader.bind(
-            input_texture=self.offscreen_color,
-        )
-        with self.ctx.scope(enable_only=moderngl.NOTHING):
-            self.ctx.depth_mask = False
-            self.copy_vao.render(copy_shader)
-            self.ctx.depth_mask = True
-
         self.water_prog["env_cube"].value = 1
-        self.water_prog["depth_tex"].value = 2
         self.water_prog["near"].value = 0.1
         self.water_prog["far"].value = 1000.0
         self.water_prog["resolution"].value = self.wnd.size
         self.water_prog["m_model"].write(self.water_model)
         self.env_cube.use(location=1)
         self.water_prog["env_cube"].value = 1
-        self.offscreen_depth.use(location=2)
-        self.water_prog["depth_tex"].value = 2
 
         self.water_sim.texture.use(location=0)
         self.water_prog["height_map"].value = 0
         self.water_prog['base_water'] = (0.2, 0.15, 0.1)
         self.water_prog['water_opaque_depth'] = 3
-
 
         self.camera.bind(self.water_prog, pos_uniform="camera_pos")
         x, y, w, h = self.wnd.viewport
@@ -592,13 +579,6 @@ class WaterApp(mglw.WindowConfig):
         #     )
 
     def on_resize(self, width: int, height: int):
-        # When the window is resized, update the offscreen framebuffer and resolution uniform.
-        self.offscreen_depth = self.ctx.depth_texture((width, height))
-        self.offscreen_color = self.ctx.texture((width, height), 4)
-        self.offscreen_fbo = self.ctx.framebuffer(
-            color_attachments=[self.offscreen_color],
-            depth_attachment=self.offscreen_depth,
-        )
         self.water_prog["resolution"].value = (width, height)
         # Create the camera.
         self.camera.set_aspect(width / height)

--- a/src/riverborn/shaders/water.frag
+++ b/src/riverborn/shaders/water.frag
@@ -4,19 +4,10 @@ in vec2 v_uv;
 in vec3 v_world;
 uniform sampler2D height_map;   // Height map for ripples.
 uniform samplerCube env_cube;     // Environment cube map.
-uniform sampler2D depth_tex;      // Depth texture from water-bottom pass.
 uniform vec3 camera_pos;
 uniform vec2 resolution;
-uniform float near;
-uniform float far;
 uniform vec3 base_water;
-uniform float water_opaque_depth;
 out vec4 f_color;
-
-// Function to linearize a non-linear depth value.
-float linearizeDepth(float depth) {
-    return (2.0 * near * far) / (far + near - depth * (far - near));
-}
 
 // Smooth normal calculation function
 vec3 calculateSmoothNormal(sampler2D heightMap, vec2 uv, float ripple_scale, float smoothness) {
@@ -71,24 +62,7 @@ void main() {
     vec3 refl_dir = reflect(-view_dir, perturbed_normal);
     vec4 refl_color = vec4(texture(env_cube, refl_dir).rgb, 1.0);
 
-    // --- Depth-based transparency.
-    // Compute screen-space coordinates.
-    vec2 screen_uv = gl_FragCoord.xy / resolution;
-    // Sample the water-bottom depth (non-linear depth).
-    float scene_depth = texture(depth_tex, screen_uv).r;
-    // Linearize the depths.
-    float scene_lin = linearizeDepth(scene_depth);
-    float water_lin = linearizeDepth(gl_FragCoord.z);
-
-    float depth_diff = scene_lin - water_lin;
-    if (depth_diff < 0.0) {
-        // If the water is above the scene, we want it to be opaque.
-        discard;
-    }
-    // When the water is shallow (small depth difference) we want more transparency.
-    float shallow = clamp(depth_diff / water_opaque_depth, 0.0, 1.0);
-
     // Mix: reflection atop base water colour.
-    vec4 diffuse = vec4(base_water, shallow);
+    vec4 diffuse = vec4(base_water, 1.0);
     f_color = mix(diffuse, refl_color, fresnel);
 }

--- a/src/riverborn/shaders/water.frag
+++ b/src/riverborn/shaders/water.frag
@@ -56,7 +56,7 @@ void main() {
 
     // --- Fresnel term.
     vec3 view_dir = normalize(camera_pos - v_world);
-    float fresnel = pow(1.0 - max(dot(perturbed_normal, view_dir), 0.0), 3.0);
+    float fresnel = pow(1.0 - max(dot(perturbed_normal, view_dir), 0.0), 5.0);
 
     // --- Reflection from the environment.
     vec3 refl_dir = reflect(-view_dir, perturbed_normal);


### PR DESCRIPTION
Remove the depth-based opacity from the water shader and make the water completely opaque while keeping the Fresnel/reflection.

* **Shader Changes:**
  - Remove the use of the `depth_tex` uniform and related calculations in `src/riverborn/shaders/water.frag`.
  - Set the water color to be completely opaque.
  - Keep the Fresnel term and reflection calculation.

* **Rendering Pipeline Changes:**
  - Remove the binding and use of the `depth_tex` uniform in the `on_render` method in `src/riverborn/mgl_terrain.py`.
  - Remove the creation of the offscreen depth texture and framebuffer in the `on_resize` method in `src/riverborn/mgl_terrain.py`.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/lordmauve/riverborn/pull/2?shareId=bb5ed320-f43b-477b-940f-fe4cc9cda8c0).